### PR TITLE
chore: harden CI/CD pipeline — concurrency, timeouts, injection fixes…

### DIFF
--- a/.github/workflows/_reusable-deploy.yml
+++ b/.github/workflows/_reusable-deploy.yml
@@ -29,6 +29,7 @@ jobs:
   deploy:
     name: Deploy to ${{ inputs.environment }}
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     environment: ${{ inputs.environment }}
     permissions:
       contents: write
@@ -91,26 +92,37 @@ jobs:
 
       - name: Record deployment
         if: always() && inputs.record_deployment
+        env:
+          DEPLOY_ENVIRONMENT: ${{ inputs.environment }}
+          DEPLOY_ACTOR: ${{ github.actor }}
+          DEPLOY_SHA: ${{ github.sha }}
+          DEPLOY_REF: ${{ github.ref_name }}
+          DEPLOY_RUN_ID: ${{ github.run_id }}
+          DEPLOY_VALIDATION_ID: ${{ inputs.validation_id }}
+          DEPLOY_TEST_LEVEL: ${{ inputs.test_level }}
+          DEPLOY_QUICK: ${{ inputs.validation_id != '' }}
+          DEPLOY_ID_QUICK: ${{ steps.quick.outputs.deploy_id }}
+          DEPLOY_ID_FULL: ${{ steps.full.outputs.deploy_id }}
+          DEPLOY_OUTCOME: ${{ job.status }}
         run: |
-          DEPLOY_ID="${{ steps.quick.outputs.deploy_id || steps.full.outputs.deploy_id }}"
-          OUTCOME="${{ job.status }}"
+          DEPLOY_ID="${DEPLOY_ID_QUICK:-$DEPLOY_ID_FULL}"
           mkdir -p deployments
-          RECORD_FILE="deployments/$(date -u +%Y-%m-%d)-${{ inputs.environment }}-${{ github.run_id }}.json"
-          cat > "$RECORD_FILE" <<EOF
+          RECORD_FILE="deployments/$(date -u +%Y-%m-%d)-${DEPLOY_ENVIRONMENT}-${DEPLOY_RUN_ID}.json"
+          cat > "$RECORD_FILE" <<RECEOF
           {
-            "environment": "${{ inputs.environment }}",
+            "environment": "${DEPLOY_ENVIRONMENT}",
             "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-            "actor": "${{ github.actor }}",
-            "commit": "${{ github.sha }}",
-            "ref": "${{ github.ref_name }}",
-            "run_id": "${{ github.run_id }}",
-            "deploy_id": "$DEPLOY_ID",
-            "validation_id": "${{ inputs.validation_id }}",
-            "quick_deploy": ${{ inputs.validation_id != '' }},
-            "test_level": "${{ inputs.test_level }}",
-            "outcome": "$OUTCOME"
+            "actor": "${DEPLOY_ACTOR}",
+            "commit": "${DEPLOY_SHA}",
+            "ref": "${DEPLOY_REF}",
+            "run_id": "${DEPLOY_RUN_ID}",
+            "deploy_id": "${DEPLOY_ID}",
+            "validation_id": "${DEPLOY_VALIDATION_ID}",
+            "quick_deploy": ${DEPLOY_QUICK},
+            "test_level": "${DEPLOY_TEST_LEVEL}",
+            "outcome": "${DEPLOY_OUTCOME}"
           }
-          EOF
+RECEOF
           echo "Deployment recorded: $RECORD_FILE"
 
           # Commit to a dedicated audit branch (deployments-ledger)
@@ -118,9 +130,9 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git fetch origin deployments-ledger:deployments-ledger 2>/dev/null || git checkout --orphan deployments-ledger
           git checkout deployments-ledger 2>/dev/null || true
-          git checkout "${{ github.sha }}" -- deployments/ 2>/dev/null || true
+          git checkout "${DEPLOY_SHA}" -- deployments/ 2>/dev/null || true
           git add deployments/ || true
-          git commit -m "chore(deploy): record ${{ inputs.environment }} deploy ${{ github.run_id }}" || echo "nothing to commit"
+          git commit -m "chore(deploy): record ${DEPLOY_ENVIRONMENT} deploy ${DEPLOY_RUN_ID}" || echo "nothing to commit"
           git push origin HEAD:deployments-ledger || echo "push failed (non-fatal)"
 
       - name: Append deployment summary

--- a/.github/workflows/_reusable-validate.yml
+++ b/.github/workflows/_reusable-validate.yml
@@ -36,7 +36,11 @@ jobs:
   validate:
     name: Validate against ${{ inputs.environment }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     environment: ${{ inputs.environment }}
+    permissions:
+      contents: read
+      actions: read
     outputs:
       nothing_to_deploy: ${{ steps.delta.outputs.nothing_to_deploy }}
       validation_id: ${{ steps.validate.outputs.validation_id }}
@@ -58,21 +62,26 @@ jobs:
 
       - name: Resolve start commit
         id: start
+        env:
+          COMMIT_HASH_INPUT: ${{ inputs.commit_hash }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          REF_NAME: ${{ github.ref_name }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          if [ -n "${{ inputs.commit_hash }}" ]; then
-            echo "Using manual override: ${{ inputs.commit_hash }}"
-            echo "sha=${{ inputs.commit_hash }}" >> "$GITHUB_OUTPUT"
+          if [ -n "$COMMIT_HASH_INPUT" ]; then
+            echo "Using manual override: $COMMIT_HASH_INPUT"
+            echo "sha=$COMMIT_HASH_INPUT" >> "$GITHUB_OUTPUT"
           else
             # Find last successful run of THIS workflow on THIS branch
             LAST_SUCCESS=$(gh run list \
-              --workflow "${{ github.workflow }}" \
-              --branch "${{ github.ref_name }}" \
+              --workflow "$WORKFLOW_NAME" \
+              --branch "$REF_NAME" \
               --status success \
               --limit 1 \
               --json headSha \
               --jq '.[0].headSha // empty')
             if [ -z "$LAST_SUCCESS" ]; then
-              echo "No prior successful run found on ${{ github.ref_name }}"
+              echo "No prior successful run found on $REF_NAME"
               # Fallback: merge-base with parent environment branch (covers first-run case)
               PARENT=$(git merge-base HEAD origin/develop || git merge-base HEAD HEAD~1 || echo "")
               if [ -z "$PARENT" ]; then
@@ -86,8 +95,6 @@ jobs:
               echo "sha=$LAST_SUCCESS" >> "$GITHUB_OUTPUT"
             fi
           fi
-        env:
-          GH_TOKEN: ${{ github.token }}
 
       - name: Generate delta package
         id: delta
@@ -123,7 +130,7 @@ jobs:
               --manifest delta/package/package.xml \
               --target-org ci-org \
               --output-dir rollback-snapshot \
-              --ignore-conflicts || echo "Snapshot retrieve had warnings (likely new components)"
+              --ignore-conflicts
           fi
 
       - name: Upload rollback snapshot

--- a/.github/workflows/cherry-pick-workflow.yml
+++ b/.github/workflows/cherry-pick-workflow.yml
@@ -1,107 +1,90 @@
-# This GitHub Actions workflow cherry‑picks pull requests that are merged into branch
-# A and have titles starting with "Cherry" into branch B automatically.  When a pull
-# request targeting branch A is closed (merged), the job checks if the PR was
-# actually merged and if its title starts with the prefix "Cherry".  If both
-# conditions are met, it checks out branch B, cherry‑picks the merge (or squash)
-# commit from the PR, and pushes the result back to the remote branch B.
+# This workflow cherry-picks pull requests merged into 'develop' whose titles
+# start with "Cherry" into the 'qa' branch automatically.
 
-name: cherry‑pick Cherry‑prefixed PRs to branch B
+name: Cherry-pick Cherry-prefixed PRs to qa
 
 on:
-  # Trigger on pull requests that are closed (merged or closed without merge).
   pull_request:
     types: [closed]
-    # Only watch pull requests whose base branch is A.
     branches:
-      - A
+      - develop
+
+concurrency:
+  group: cherry-pick-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
 
 jobs:
   cherry_pick:
-    # Only run if the pull request was merged AND its title starts with "Cherry".
     if: ${{ github.event.pull_request.merged == true && startsWith(github.event.pull_request.title, 'Cherry') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
-      # Grant write permissions so the workflow can push to the repository.
       contents: write
 
     steps:
       - name: Checkout repository with full history
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          # A full fetch is required so that cherry‑picking works correctly.
           fetch-depth: 0
-          # Use the GITHUB_TOKEN to authenticate against the repository.
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure Git user
+        env:
+          GIT_ACTOR: ${{ github.actor }}
         run: |
-          git config --global user.name "${{ github.actor }}"
-          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+          git config --global user.name "$GIT_ACTOR"
+          git config --global user.email "${GIT_ACTOR}@users.noreply.github.com"
 
-      - name: Prepare target branch
-        run: |
-          # Fetch remote branches and create a local copy of B if it does not exist.
-          git fetch origin
-          if git show-ref --verify --quiet refs/heads/B; then
-            echo "Local branch B exists."
-          else
-            # Create B from origin/B if it exists or from current HEAD otherwise.
-            if git ls-remote --exit-code --heads origin B; then
-              git checkout -b B origin/B
-            else
-              # If B doesn’t exist remotely, create it from branch A’s latest state.
-              git checkout -b B origin/A
-              git push --set-upstream origin B
-            fi
-          fi
-
-      - name: Cherry‑pick pull request commits into target branch
+      - name: Cherry-pick PR commit into qa
+        env:
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          TARGET_BRANCH: qa
         run: |
           set -euo pipefail
 
-          # Identify the base branch (A) and the head branch (source of PR) from the event
-          base_branch="${{ github.event.pull_request.base.ref }}"
-          source_branch="${{ github.event.pull_request.head.ref }}"
-          target_branch="B"
-
-          echo "Base branch: $base_branch"
-          echo "Source branch: $source_branch"
-          echo "Target branch: $target_branch"
-
-          # Ensure we have the latest history for all branches
-          git fetch origin
-
-          # Check out the target branch locally (create if missing)
-          if git show-ref --verify --quiet refs/heads/$target_branch; then
-            git checkout $target_branch
-            git pull origin $target_branch
-          else
-            # Create target branch from base branch if it doesn't exist
-            git checkout -b $target_branch origin/$base_branch
+          if [ -z "$MERGE_SHA" ]; then
+            echo "::error::merge_commit_sha is empty — cannot cherry-pick." >&2
+            exit 1
           fi
 
-          # Fetch the full source branch to ensure we have all its commits
-          git fetch origin $source_branch:$source_branch
+          echo "Merge SHA: $MERGE_SHA"
+          echo "Target branch: $TARGET_BRANCH"
 
-          # Determine the list of commits that are in the source branch but not in the base branch.
-          # We use --reverse to apply commits in chronological order and exclude merge commits.
-          commit_list=$(git rev-list --reverse --no-merges origin/$source_branch ^origin/$base_branch)
+          git fetch origin
 
-          echo "Commits to cherry‑pick: $commit_list"
+          # Ensure we have the target branch locally
+          if git show-ref --verify --quiet "refs/heads/$TARGET_BRANCH"; then
+            git checkout "$TARGET_BRANCH"
+            git pull origin "$TARGET_BRANCH"
+          else
+            git checkout -b "$TARGET_BRANCH" "origin/$TARGET_BRANCH"
+          fi
 
-          # Loop through each commit and cherry‑pick it with the recursive merge strategy.
-          # If a cherry‑pick fails, abort and exit with a non-zero status so the job fails.
-          for sha in $commit_list; do
-            echo "Cherry‑picking $sha into $target_branch"
-            if git cherry-pick --strategy=recursive -X theirs -x "$sha"; then
-              echo "Successfully cherry‑picked $sha."
-            else
-              echo "Conflict detected while cherry‑picking $sha. Aborting…" >&2
+          # Detect whether the merge commit has 2 parents (regular merge) or 1 (squash merge)
+          PARENT_COUNT=$(git log -1 --format='%P' "$MERGE_SHA" | wc -w | tr -d ' ')
+          echo "Parent count for $MERGE_SHA: $PARENT_COUNT"
+
+          if [ "$PARENT_COUNT" -ge 2 ]; then
+            # Regular merge commit: use -m 1 to cherry-pick against the first (base) parent
+            echo "Cherry-picking merge commit with -m 1"
+            if ! git cherry-pick -m 1 -x "$MERGE_SHA"; then
+              echo "::error::Conflict during cherry-pick of $MERGE_SHA. Aborting." >&2
               git cherry-pick --abort
               exit 1
             fi
-          done
+          else
+            # Squash merge: single-parent commit, cherry-pick directly
+            echo "Cherry-picking squash-merge commit"
+            if ! git cherry-pick -x "$MERGE_SHA"; then
+              echo "::error::Conflict during cherry-pick of $MERGE_SHA. Aborting." >&2
+              git cherry-pick --abort
+              exit 1
+            fi
+          fi
+          echo "Successfully cherry-picked $MERGE_SHA into $TARGET_BRANCH."
 
-      - name: Push changes to target branch
+      - name: Push changes to qa
+        env:
+          TARGET_BRANCH: qa
         run: |
-          git push origin B
+          git push origin "$TARGET_BRANCH"

--- a/.github/workflows/cleanup-branches.yml
+++ b/.github/workflows/cleanup-branches.yml
@@ -24,18 +24,15 @@ permissions:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
       - name: Delete stale and merged branches
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const DAYS_OLD = parseInt('${{ github.event.inputs.days_old || 60 }}', 10);
-            const DRY_RUN = '${{ github.event.inputs.dry_run || 'true' }}' === 'true';
+            const DRY_RUN = '${{ github.event.inputs.dry_run || 'false' }}' === 'true';
 
             const PROTECTED_BRANCHES = [
               'main', 'master', 'develop', 'qa', 'stage', 'pre-prod-validation',

--- a/.github/workflows/drift-detection.yml
+++ b/.github/workflows/drift-detection.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   drift-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     environment: sfprod-validation
 
     steps:
@@ -42,7 +43,7 @@ jobs:
             --manifest manifest/package.xml \
             --target-org ci-org \
             --output-dir drift-check \
-            --ignore-conflicts || true
+            --ignore-conflicts
 
       - name: Diff org against main
         id: diff
@@ -107,5 +108,34 @@ jobs:
                 title,
                 body,
                 labels: ['drift'],
+              });
+            }
+
+      - name: Auto-close drift issue when no drift found
+        if: steps.diff.outputs.drift_found == 'false'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = '⚠️ Drift detected between Prod org and main';
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'drift',
+              creator: 'github-actions[bot]',
+            });
+            const existing = issues.data.find(i => i.title === title);
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body: `✅ Drift resolved as of ${new Date().toISOString().split('T')[0]}. No differences detected between org and main. Closing automatically.`,
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                state: 'closed',
               });
             }

--- a/.github/workflows/first-run-baseline.yml
+++ b/.github/workflows/first-run-baseline.yml
@@ -14,6 +14,9 @@ on:
 jobs:
   baseline:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -21,10 +24,15 @@ jobs:
           ref: ${{ github.event.inputs.branch }}
 
       - name: Record baseline
+        env:
+          BASELINE_BRANCH: ${{ github.event.inputs.branch }}
+          BASELINE_SHA: ${{ github.sha }}
         run: |
-          echo "## Baseline established"
-          echo "**Branch:** ${{ github.event.inputs.branch }}"
-          echo "**Commit:** ${{ github.sha }}"
-          echo ""
-          echo "Subsequent deployment runs on this branch will use this commit"
-          echo "as the start point for delta generation." >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Baseline established"
+            echo "**Branch:** ${BASELINE_BRANCH}"
+            echo "**Commit:** ${BASELINE_SHA}"
+            echo ""
+            echo "Subsequent deployment runs on this branch will use this commit"
+            echo "as the start point for delta generation."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -18,15 +18,26 @@ on:
       confirm:
         description: Type ROLLBACK to confirm
         required: true
+      test_level:
+        description: 'Test level for rollback deploy (default: RunLocalTests; use NoTestRun for speed in emergency)'
+        required: false
+        type: choice
+        options: [RunLocalTests, NoTestRun, RunSpecifiedTests, RunAllTestsInOrg]
+        default: RunLocalTests
 
 permissions:
   actions: read
   contents: read
 
+concurrency:
+  group: rollback-${{ github.event.inputs.environment }}
+  cancel-in-progress: false
+
 jobs:
   rollback:
     if: github.event.inputs.confirm == 'ROLLBACK'
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     environment: ${{ github.event.inputs.environment }}
 
     steps:
@@ -53,6 +64,8 @@ jobs:
           login_url: ${{ secrets.SF_LOGIN_URL }}
 
       - name: Deploy snapshot back to org
+        env:
+          ROLLBACK_TEST_LEVEL: ${{ github.event.inputs.test_level || 'RunLocalTests' }}
         run: |
           set -euo pipefail
           if [ ! -d rollback-snapshot ] || [ -z "$(ls -A rollback-snapshot 2>/dev/null)" ]; then
@@ -62,7 +75,7 @@ jobs:
           sf project deploy start \
             --source-dir rollback-snapshot \
             --target-org ci-org \
-            --test-level RunLocalTests \
+            --test-level "$ROLLBACK_TEST_LEVEL" \
             --wait 60 \
             --json > rollback-result.json
           DEPLOY_ID=$(jq -r '.result.id' rollback-result.json)
@@ -70,12 +83,17 @@ jobs:
 
       - name: Append rollback summary
         if: always()
+        env:
+          ROLLBACK_ENV: ${{ github.event.inputs.environment }}
+          ROLLBACK_RUN_ID: ${{ github.event.inputs.run_id }}
+          ROLLBACK_ACTOR: ${{ github.actor }}
+          ROLLBACK_OUTCOME: ${{ job.status }}
         run: |
           {
             echo "## Rollback summary"
             echo ""
-            echo "**Environment:** ${{ github.event.inputs.environment }}"
-            echo "**Original run:** ${{ github.event.inputs.run_id }}"
-            echo "**Rollback outcome:** ${{ job.status }}"
-            echo "**Triggered by:** ${{ github.actor }}"
+            echo "**Environment:** ${ROLLBACK_ENV}"
+            echo "**Original run:** ${ROLLBACK_RUN_ID}"
+            echo "**Rollback outcome:** ${ROLLBACK_OUTCOME}"
+            echo "**Triggered by:** ${ROLLBACK_ACTOR}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/salesforce-pr-review.yml
+++ b/.github/workflows/salesforce-pr-review.yml
@@ -16,9 +16,15 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   review:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout PR head
         uses: actions/checkout@v4
@@ -36,6 +42,7 @@ jobs:
         run: npm install --no-audit --no-fund
 
       - name: Run review (static + AI)
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/sfdev.yml
+++ b/.github/workflows/sfdev.yml
@@ -10,9 +10,14 @@ on:
         required: false
         default: ''
 
+concurrency:
+  group: deploy-sfdev
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: read
+  actions: read
 
 jobs:
   validate:

--- a/.github/workflows/sfpreprodvalidation.yml
+++ b/.github/workflows/sfpreprodvalidation.yml
@@ -13,9 +13,14 @@ on:
         required: false
         default: ''
 
+concurrency:
+  group: deploy-sfprod-validation
+  cancel-in-progress: false
+
 permissions:
   contents: read
   pull-requests: read
+  actions: read
 
 jobs:
   validate:

--- a/.github/workflows/sfprod.yml
+++ b/.github/workflows/sfprod.yml
@@ -15,9 +15,14 @@ on:
         required: false
         default: ''
 
+concurrency:
+  group: deploy-sfprod
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: read
+  actions: read
 
 jobs:
   validate:

--- a/.github/workflows/sfqa.yml
+++ b/.github/workflows/sfqa.yml
@@ -9,9 +9,14 @@ on:
         required: false
         default: ''
 
+concurrency:
+  group: deploy-sfqa
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: read
+  actions: read
 
 jobs:
   validate:

--- a/.github/workflows/sfstage.yml
+++ b/.github/workflows/sfstage.yml
@@ -9,9 +9,14 @@ on:
         required: false
         default: ''
 
+concurrency:
+  group: deploy-sfstage
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: read
+  actions: read
 
 jobs:
   validate:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Salesforce DevOps Pipeline
 
-A production-grade Salesforce CI/CD pipeline for GitHub, with an AI-powered PR review bot, quick-deploy, rollback, drift detection, and a deployment ledger.
+A production-grade Salesforce CI/CD pipeline for GitHub, with an AI-powered PR review bot, quick-deploy, rollback, drift detection, automatic cherry-picking, and a deployment ledger.
 
-This README walks you through the setup from a fresh repo to your first production deployment, then explains how the AI review agent works on a real pull request.
+This README covers setup from a fresh repo to first production deployment, a complete walkthrough of every workflow trigger and execution order, and all improvements shipped in the `chore/workflow-improvements` branch.
 
 ---
 
@@ -16,28 +16,35 @@ This README walks you through the setup from a fresh repo to your first producti
 6. [Anthropic API key — for the AI review agent](#anthropic-api-key--for-the-ai-review-agent)
 7. [First-run baseline](#first-run-baseline)
 8. [Branch and environment model](#branch-and-environment-model)
-9. [How the AI review agent works](#how-the-ai-review-agent-works)
-10. [Architectural improvements over a baseline pipeline](#architectural-improvements-over-a-baseline-pipeline)
-11. [Operational runbooks](#operational-runbooks)
-12. [Cost reference](#cost-reference)
-13. [Troubleshooting](#troubleshooting)
+9. [Workflow trigger map — full execution order](#workflow-trigger-map--full-execution-order)
+10. [Workflow reference — every file explained](#workflow-reference--every-file-explained)
+11. [How the AI review agent works](#how-the-ai-review-agent-works)
+12. [Architectural improvements](#architectural-improvements)
+13. [Operational runbooks](#operational-runbooks)
+14. [Cost reference](#cost-reference)
+15. [Troubleshooting](#troubleshooting)
+16. [Repository layout](#repository-layout)
 
 ---
 
 ## What you get
 
-| Capability | File(s) |
+| Capability | Workflow / File |
 |---|---|
-| Validate then deploy on every push | `.github/workflows/_reusable-validate.yml`, `_reusable-deploy.yml` |
-| Per-environment workflows (dev, qa, stage, pre-prod, prod) | `.github/workflows/sf*.yml` |
+| Validate then deploy on every push | `_reusable-validate.yml`, `_reusable-deploy.yml` |
+| Per-environment pipelines (dev, qa, stage, pre-prod, prod) | `sfdev.yml`, `sfqa.yml`, `sfstage.yml`, `sfpreprodvalidation.yml`, `sfprod.yml` |
 | Quick-deploy using validation IDs (60–80% faster prod deploys) | `.github/actions/sf-quick-deploy/action.yml` |
-| Pre-deploy snapshot + manual rollback | `.github/workflows/rollback.yml` |
-| Weekly drift detection (org vs `main`) with auto-issue | `.github/workflows/drift-detection.yml` |
+| Pre-deploy snapshot + manual rollback with configurable test level | `rollback.yml` |
+| Weekly drift detection with auto-open **and auto-close** of issues | `drift-detection.yml` |
 | Deployment ledger committed to a separate branch | `_reusable-deploy.yml` (Record deployment step) |
-| Two-layer PR review bot — static rules + Claude Sonnet | `.github/scripts/review.js`, `ai-review.js`, `rules/*` |
+| Two-layer PR review bot — static rules + Claude Sonnet (skips Dependabot) | `.github/scripts/review.js`, `ai-review.js`, `rules/*` |
 | Dynamic Apex test selection | `.github/scripts/GenerateSfdxCommand.js` |
-| Stale branch cleanup | `.github/workflows/cleanup-branches.yml` |
-| First-run baseline workflow | `.github/workflows/first-run-baseline.yml` |
+| Stale branch cleanup (runs live on schedule, dry-run on manual dispatch) | `cleanup-branches.yml` |
+| Auto cherry-pick Cherry-prefixed PRs from `develop` → `qa` | `cherry-pick-workflow.yml` |
+| First-run baseline workflow | `first-run-baseline.yml` |
+| Concurrency guards on every workflow (no duplicate deploys) | All workflows |
+| Timeout guards on every job (no hung runners) | All workflows |
+| Shell injection hardening (all user inputs via `env:` blocks) | All `run:` steps |
 
 ---
 
@@ -46,13 +53,11 @@ This README walks you through the setup from a fresh repo to your first producti
 - A GitHub repository (this one)
 - Access to your target Salesforce orgs (Dev, QA, Stage, Pre-Prod, Prod)
 - A workstation with `openssl`, `git`, and `sf` (Salesforce CLI v2) installed
-- An Anthropic API key (only needed for the AI review layer — the rest of the pipeline works without it)
+- An Anthropic API key (optional — only needed for the AI review layer)
 
 ---
 
 ## Repository setup
-
-Drop this bundle into your repo as-is, or migrate piece by piece:
 
 ```bash
 # 1. Clone your existing repo
@@ -62,7 +67,7 @@ cd <your-repo>
 # 2. Copy the bundle on top
 unzip salesforce-pipeline-bundle.zip -d .
 
-# 3. Install PR review bot dependencies (one-time, locally — CI does this too)
+# 3. Install PR review bot dependencies (one-time locally — CI does this too)
 cd .github/scripts && npm install && cd ../..
 
 # 4. Commit
@@ -72,7 +77,7 @@ git commit -m "chore: bring in DevOps pipeline + AI review bot"
 git push -u origin chore/pipeline-setup
 ```
 
-Open a PR from `chore/pipeline-setup` to `develop` to verify the PR review bot fires (it will). Once you've reviewed its output, merge into `develop`.
+Open a PR from `chore/pipeline-setup` to `develop` to verify the PR review bot fires. Once reviewed, merge into `develop`.
 
 ---
 
@@ -82,8 +87,6 @@ JWT Bearer Flow is the auth mechanism. No passwords are stored anywhere.
 
 ### 1. Generate the keypair
 
-On your workstation:
-
 ```bash
 mkdir -p /tmp/sfjwt && cd /tmp/sfjwt
 openssl genrsa -out server.key 2048
@@ -91,7 +94,6 @@ openssl req -new -key server.key -out server.csr -subj "/C=GB/O=YourCompany/CN=c
 openssl x509 -req -sha256 -days 730 -in server.csr -signkey server.key -out server.crt
 ```
 
-You now have:
 - `server.key` — the **private key** (goes into GitHub secrets, never into git)
 - `server.crt` — the **certificate** (uploaded to the Connected App)
 
@@ -100,23 +102,20 @@ You now have:
 In **each** target org (Dev, QA, Stage, Pre-Prod, Prod):
 
 1. Setup → App Manager → **New Connected App**
-2. Connected App Name: `CI/CD Integration`
-3. API (Enable OAuth Settings):
+2. API (Enable OAuth Settings):
    - **Enable OAuth Settings:** ✓
-   - **Callback URL:** `http://localhost:1717/OauthRedirect` (placeholder — JWT doesn't use it)
+   - **Callback URL:** `http://localhost:1717/OauthRedirect`
    - **Use digital signatures:** ✓ — upload `server.crt`
    - **Selected OAuth Scopes:** `Manage user data via APIs (api)`, `Perform requests at any time (refresh_token, offline_access)`
-4. Save. After creating, click **Manage** → **Edit Policies** → set **Permitted Users** to `Admin approved users are pre-authorized`.
-5. Note the **Consumer Key** — this is `SF_CLIENT_ID`.
+3. Save. **Manage** → **Edit Policies** → set **Permitted Users** to `Admin approved users are pre-authorized`.
+4. Note the **Consumer Key** — this is `SF_CLIENT_ID`.
 
 ### 3. Create the integration user and permission set
 
-1. Setup → Users → **New User** — e.g. `ci-integration@yourcompany.com.prod` (use a `+ci` alias on a real address you control). Profile: **System Administrator** is simplest; for a tighter setup, use a custom profile with API access.
-2. Create a permission set `CI_CD_Integration` with:
-   - System Permissions: **API Enabled**, **Modify Metadata Through Metadata API Functions**, **Modify All Data**
-   - Object permissions matching what you actually deploy (Read/Create/Edit/Delete on standard and custom objects you touch)
+1. Setup → Users → **New User** (e.g., `ci-integration@yourcompany.com.prod`). Profile: **System Administrator** for simplest setup.
+2. Create a permission set `CI_CD_Integration` with **API Enabled**, **Modify Metadata Through Metadata API Functions**, **Modify All Data**.
 3. Assign the permission set to the integration user.
-4. Back on the Connected App: **Manage** → **Manage Profiles** (or Permission Sets) — pre-authorize the integration user's profile/permission set.
+4. Back on the Connected App: **Manage** → pre-authorize the integration user's profile/permission set.
 
 ### 4. Test the JWT flow locally
 
@@ -131,13 +130,11 @@ sf org login jwt \
 sf org display --target-org prod-ci
 ```
 
-If that works, the GitHub Actions auth will work too. Repeat for each org you want the pipeline to deploy to.
+If this works, the GitHub Actions auth will work too. Repeat for each org.
 
 ---
 
 ## GitHub setup — environments and secrets
-
-The pipeline uses **GitHub Environments** so each Salesforce org has its own scoped secrets and (for prod) approval gates.
 
 ### 1. Create environments
 
@@ -147,22 +144,20 @@ Repository → **Settings** → **Environments** → **New environment** for eac
 - `sfqa`
 - `sfstage`
 - `sfprod`
-- `sfprod-validation` (used by the pre-prod-validation and drift-detection workflows)
+- `sfprod-validation` (used by pre-prod-validation and drift-detection)
 
-For `sfprod`: enable **Required reviewers** and add yourself + at least one other person. This is your manual approval gate before any prod deploy.
+For `sfprod`: enable **Required reviewers** and add yourself + at least one other person. This is the manual approval gate before any prod deploy.
 
 ### 2. Add secrets to each environment
 
-Inside each environment, **Add secret**:
-
 | Secret name | Value |
 |---|---|
-| `SF_CLIENT_ID` | The Connected App Consumer Key for that org |
+| `SF_CLIENT_ID` | Connected App Consumer Key for that org |
 | `SF_USERNAME` | Integration user username for that org |
-| `SF_LOGIN_URL` | `https://login.salesforce.com` for prod, `https://test.salesforce.com` for sandboxes |
-| `SF_JWT_KEY` | Full contents of `server.key` (paste the whole `-----BEGIN PRIVATE KEY-----` block, with newlines) |
+| `SF_LOGIN_URL` | `https://login.salesforce.com` for prod; `https://test.salesforce.com` for sandboxes |
+| `SF_JWT_KEY` | Full contents of `server.key` including `-----BEGIN/END PRIVATE KEY-----` lines |
 
-> Tip: you can use the **same** JWT keypair across all orgs (one Connected App per org, all trusting the same cert). This means just one `SF_JWT_KEY` to rotate quarterly — the rotation procedure becomes generating a new key, uploading the new cert to all five Connected Apps, then updating the secret.
+> You can use one JWT keypair across all orgs — just upload the same `server.crt` to each Connected App. One `SF_JWT_KEY` to rotate quarterly.
 
 ### 3. Branch protection
 
@@ -179,14 +174,13 @@ Repository → **Settings** → **Branches** → **Add rule**:
 
 ## Anthropic API key — for the AI review agent
 
-The AI review layer is **optional** — without an API key, only the static rules layer runs and PRs still get reviewed. With a key, you also get the cross-file impact analysis described below.
+The AI review layer is **optional** — without a key, only the static rules layer runs. With a key you also get cross-file impact analysis.
 
 ### 1. Get an API key
 
 1. Sign in at <https://console.anthropic.com>
 2. Workspaces → your workspace → **API Keys** → **Create Key**
-3. Name it `github-pr-review-bot` so usage shows up cleanly on the Usage page
-4. Copy the key (starts with `sk-ant-`)
+3. Name it `github-pr-review-bot`
 
 ### 2. Add to GitHub
 
@@ -196,141 +190,510 @@ Repository → **Settings** → **Secrets and variables** → **Actions** → **
 |---|---|
 | `ANTHROPIC_API_KEY` | The `sk-ant-...` key |
 
-It's a **repository** secret (not environment-scoped) because PR reviews run before any environment context is established.
+This is a **repository** secret (not environment-scoped) because PR reviews run before any environment context is established.
 
 ### 3. Verify
 
-Open any PR. Within ~30 seconds the `Salesforce PR Review` workflow should run and post a review. Look at the workflow log — you'll see:
+Open any PR. The `Salesforce PR Review` workflow runs automatically. Look at the log for:
 
 ```
 AI review: 3 logic file(s), 4 context file(s), ~3,200 input tokens estimated
 AI review: tokens used — input: 3418, output: 612, cache_read: 820, cache_write: 0
 ```
 
-That's the AI layer running. If you don't see those lines, the layer was skipped (XML-only PR) or the key isn't set.
+If you don't see those lines, the layer was skipped (XML-only PR) or the key isn't set.
 
 ---
 
 ## First-run baseline
 
-The validate workflow needs a **starting commit** to compute the delta against. On a brand-new branch with no prior successful runs, it falls back to the merge-base with `develop`. To avoid relying on that fallback, run the baseline workflow once per branch:
+The validate workflow needs a starting commit to compute the delta. On a brand-new branch with no prior successful runs it falls back to the merge-base with `develop`. To use an explicit baseline:
 
 1. **Actions** → **First-Run Baseline** → **Run workflow**
 2. Pick the branch (`develop`, `qa`, `stage`, `main`)
 3. Run
 
-Subsequent pushes on that branch use the previous successful run as the delta start point. You only need to do this once per branch, ever.
+The step summary will show:
+
+```
+## Baseline established
+Branch: develop
+Commit: abc1234...
+Subsequent deployment runs on this branch will use this commit as the start point for delta generation.
+```
+
+You only need to do this once per branch, ever.
 
 ---
 
 ## Branch and environment model
 
 ```
-feature/* ──PR──▶ develop ──▶ qa ──▶ stage ──▶ pre-prod-validation ──▶ main
-              │           │       │           │                       │
-              │ sfdev.yml │ sfqa  │ sfstage   │ sfpreprodvalidation   │ sfprod.yml
-              │ → SF Dev  │ → QA  │ → Stage   │ → Pre-Prod (val only) │ → Prod
-              │           │       │           │                       │
-   PR review ─┘           │       │           │                       │
-   (every PR              │       │           │                       │
-    to any branch)        │       │           │                       │
-                          │       │           │                       │
-                          └───────┴───────────┴───────────────────────┘
-                          Each push triggers validate → quick-deploy
+feature/* ──PR──▶ develop ──push──▶ qa ──push──▶ stage ──push──▶ pre-prod-validation ──push──▶ main
+              │                │                                                              │
+              │ PR Review Bot  │ Cherry-pick                                                  │
+              │ (static+AI)    │ (Cherry-prefixed                                             │
+              │                │  PRs → qa)                                                   │
+              ▼                ▼                                                              ▼
+         sfdev.yml          sfqa.yml          sfstage.yml    sfpreprodvalidation.yml     sfprod.yml
+         → SF Dev org       → SF QA org       → SF Stage org → Pre-Prod (validate only)  → SF Prod org
+                                                                                           ⏸ Manual approval
 ```
 
-| Branch | Environment | Test level | Approval gate |
-|---|---|---|---|
-| `develop` | sfdev | RunSpecifiedTests | none |
-| `qa` | sfqa | RunLocalTests | none |
-| `stage` | sfstage | RunLocalTests | none |
-| `pre-prod-validation` | sfprod-validation | RunAllTestsInOrg | n/a (validate-only) |
-| `main` | sfprod | RunAllTestsInOrg | manual reviewers |
+| Branch | Environment | Test level | Approval gate | Notes |
+|---|---|---|---|---|
+| `develop` | `sfdev` | RunSpecifiedTests | None | Dynamic test selection via `GenerateSfdxCommand.js` |
+| `qa` | `sfqa` | RunLocalTests | None | Also receives auto cherry-picks from `develop` |
+| `stage` | `sfstage` | RunLocalTests | None | |
+| `pre-prod-validation` | `sfprod-validation` | RunAllTestsInOrg | None | Validate-only — never deploys |
+| `main` | `sfprod` | RunAllTestsInOrg | **Manual reviewer approval** | Quick-deploy after approval |
 
-Two-stage pattern within each environment:
+### Two-stage pattern inside each environment
 
-1. **Validate** — generates delta, snapshots current org state for rollback, runs dry-run deploy, captures a 10-day-valid validation ID.
-2. **Deploy** — uses **quick-deploy** with that validation ID (no test re-run, much faster). Falls back to a full deploy if no validation ID was provided.
+Every push to `develop`, `qa`, `stage`, `pre-prod-validation`, or `main` runs two jobs in sequence:
 
-Flags that control the pipeline:
+```
+Push to branch
+     │
+     ▼
+┌─────────────────────────────────────────────────────────┐
+│  Job 1: validate  (calls _reusable-validate.yml)        │
+│  ─────────────────────────────────────────────────────  │
+│  1. Checkout (full history)                             │
+│  2. Install SF CLI + sfdx-git-delta plugin              │
+│  3. Resolve start commit                                │
+│     ├─ If manual override: use that commit              │
+│     ├─ If prior successful run on branch: use that SHA  │
+│     └─ Fallback: git merge-base with origin/develop     │
+│  4. Generate delta package (start..HEAD)                │
+│  5. If nothing_to_deploy=true → skip to summary         │
+│  6. Generate dynamic Apex test list                     │
+│  7. Authenticate to Salesforce (JWT)                    │
+│  8. Snapshot current org state → upload artifact        │
+│     (rollback-snapshot-<env>-<run_id>, 30-day retention)│
+│  9. Validate deployment (dry-run, captures validation_id)│
+│  10. Append step summary                                │
+│                                                         │
+│  Outputs: nothing_to_deploy, validation_id, delta_summary│
+└─────────────────────────────────────────────────────────┘
+     │
+     │ (if nothing_to_deploy != 'true')
+     ▼
+┌─────────────────────────────────────────────────────────┐
+│  Job 2: deploy  (calls _reusable-deploy.yml)            │
+│  ─────────────────────────────────────────────────────  │
+│  1. Checkout (full history)                             │
+│  2. Install SF CLI + sfdx-git-delta plugin              │
+│  3. Authenticate to Salesforce (JWT)                    │
+│  4. Run pre-deployment Apex scripts (.github/pre-deployment/*.apex)│
+│  5a. Quick-deploy (if validation_id provided)           │
+│      └─ sf project deploy quick --job-id <validation_id>│
+│  5b. Full deploy (if no validation_id)                  │
+│      ├─ Regenerate delta                                │
+│      └─ sf project deploy start --manifest delta/...   │
+│  6. Run post-deployment Apex scripts (.github/post-deployment/*.apex)│
+│  7. Record deployment → commit JSON to deployments-ledger branch│
+│  8. Append step summary                                 │
+└─────────────────────────────────────────────────────────┘
+```
 
-| Output | Meaning |
-|---|---|
-| `nothing_to_deploy=true` | No metadata changes — deploy job is skipped entirely |
-| `validation_id=<id>` | Quick-deploy ID from the validate job, passed to deploy |
+> For `sfprod` only: the deploy job is protected by the `sfprod` GitHub environment — it pauses and waits for a human approver before running. For all other environments, it runs immediately after validate succeeds.
+
+---
+
+## Workflow trigger map — full execution order
+
+This section shows exactly **what event triggers each workflow**, what it does step-by-step, and how workflows interact.
+
+---
+
+### 1. Developer pushes to a feature branch
+
+**Trigger:** `push` to any branch (no workflow fires — but the PR review bot fires on PR open)
+
+---
+
+### 2. Developer opens or updates a PR
+
+**Trigger:** `pull_request` types `[opened, synchronize, reopened]` to `develop`, `qa`, `stage`, or `main`
+
+```
+PR opened/updated
+      │
+      ├─ Skip if: PR author is dependabot[bot]
+      │
+      ▼
+salesforce-pr-review.yml
+  concurrency: pr-review-<PR number> (cancel-in-progress: true — old reviews superseded)
+  timeout: 15 min
+      │
+      ├─ Checkout PR head commit
+      ├─ Setup Node 20
+      ├─ npm install (review bot deps)
+      └─ Run review.js (continue-on-error: true — review bot crash never blocks merge)
+           │
+           ├─ Layer 1: Static rules engine
+           │    ├─ Parse PR diff
+           │    ├─ Run 30+ pattern rules (SOQL in loop, DML in loop, sharing violations, etc.)
+           │    └─ Collect findings with severity/location
+           │
+           └─ Layer 2: Claude Sonnet AI (only if ANTHROPIC_API_KEY is set and PR has logic files)
+                ├─ Cost guard: skip if XML-only PR
+                ├─ Collect changed logic files + up to 8 context files
+                ├─ Cap input to ~12,500 tokens
+                ├─ Call Claude Sonnet with read-only instruction
+                └─ Collect AI findings
+                     │
+                     └─ Post single PR review with inline comments
+                          🔴 high = REQUEST_CHANGES
+                          🟡 medium / 🔵 low = COMMENT only
+```
+
+---
+
+### 3. Push to `develop`
+
+**Trigger:** `push` to `develop` branch OR `workflow_dispatch` with optional `commit_hash`
+
+```
+Push to develop
+      │
+      ▼
+sfdev.yml
+  concurrency: deploy-sfdev (cancel-in-progress: false — no duplicate deploys)
+  permissions: contents:write, pull-requests:read, actions:read
+      │
+      ├─ Job 1: validate (calls _reusable-validate.yml, environment: sfdev, test_level: RunSpecifiedTests)
+      │    └─ [see two-stage pattern above]
+      │
+      └─ Job 2: deploy (calls _reusable-deploy.yml, only if nothing_to_deploy != 'true')
+           └─ [see two-stage pattern above]
+```
+
+---
+
+### 4. PR merged to `develop` with a "Cherry"-prefixed title
+
+**Trigger:** `pull_request` type `[closed]` targeting `develop`, merged=true, title starts with "Cherry"
+
+```
+PR merged to develop (title starts with "Cherry")
+      │
+      ▼
+cherry-pick-workflow.yml
+  concurrency: cherry-pick-<PR number> (cancel-in-progress: false)
+  timeout: 15 min
+      │
+      ├─ Checkout full history
+      ├─ Configure git user (via env var — injection-safe)
+      └─ Cherry-pick PR commit into qa
+           │
+           ├─ Guard: exit if merge_commit_sha is empty
+           ├─ Fetch origin
+           ├─ Checkout qa branch (create from origin/qa if missing)
+           ├─ Detect commit type: count parents of merge_commit_sha
+           │    ├─ 2+ parents = regular merge → git cherry-pick -m 1 -x <sha>
+           │    └─ 1 parent = squash merge → git cherry-pick -x <sha>
+           ├─ On conflict: abort and fail with ::error:: annotation
+           └─ git push origin qa
+```
+
+> Pushing to `qa` triggers `sfqa.yml` automatically — the cherry-picked change is deployed to QA without any manual step.
+
+---
+
+### 5. Push to `qa`
+
+**Trigger:** `push` to `qa` branch OR `workflow_dispatch`
+
+```
+Push to qa (direct push or triggered by cherry-pick)
+      │
+      ▼
+sfqa.yml
+  concurrency: deploy-sfqa (cancel-in-progress: false)
+  permissions: contents:write, pull-requests:read, actions:read
+      │
+      ├─ Job 1: validate (environment: sfqa, test_level: RunLocalTests)
+      └─ Job 2: deploy (if nothing_to_deploy != 'true')
+```
+
+---
+
+### 6. Push to `stage`
+
+**Trigger:** `push` to `stage` branch OR `workflow_dispatch`
+
+```
+Push to stage
+      │
+      ▼
+sfstage.yml
+  concurrency: deploy-sfstage (cancel-in-progress: false)
+  permissions: contents:write, pull-requests:read, actions:read
+      │
+      ├─ Job 1: validate (environment: sfstage, test_level: RunLocalTests)
+      └─ Job 2: deploy (if nothing_to_deploy != 'true')
+```
+
+---
+
+### 7. Push to `pre-prod-validation`
+
+**Trigger:** `push` to `pre-prod-validation` OR `workflow_dispatch`
+
+```
+Push to pre-prod-validation
+      │
+      ▼
+sfpreprodvalidation.yml
+  concurrency: deploy-sfprod-validation (cancel-in-progress: false)
+  permissions: contents:read, pull-requests:read, actions:read
+      │
+      └─ Job 1: validate ONLY (environment: sfprod-validation, test_level: RunAllTestsInOrg)
+           └─ No deploy job — this workflow only validates, never deploys
+                Purpose: dry-run the eventual prod deploy against a Pre-Prod mirror org
+```
+
+---
+
+### 8. Push to `main` (production deployment)
+
+**Trigger:** `push` to `main` OR `workflow_dispatch`
+
+```
+Push to main
+      │
+      ▼
+sfprod.yml
+  concurrency: deploy-sfprod (cancel-in-progress: false)
+  permissions: contents:write, pull-requests:read, actions:read
+      │
+      ├─ Job 1: validate (environment: sfprod, test_level: RunAllTestsInOrg)
+      │    └─ Full test suite, typically 25–40 min
+      │    └─ Outputs: validation_id (valid 10 days)
+      │
+      └─ Job 2: deploy ── needs: [validate] ── environment: sfprod
+           │
+           ⏸ PAUSED — waits for manual approval from sfprod environment reviewers
+           │
+           ▼ (after human approves in GitHub Actions UI)
+           └─ Quick-deploy using validation_id (3–8 min, no test re-run)
+                └─ Writes record to deployments-ledger branch
+```
+
+---
+
+### 9. Manual rollback
+
+**Trigger:** `workflow_dispatch` only — requires `environment`, `run_id`, `confirm=ROLLBACK`, optional `test_level`
+
+```
+Manual: Actions → Rollback Deployment → Run workflow
+  inputs: environment, run_id, confirm="ROLLBACK", test_level (default: RunLocalTests)
+      │
+      ▼
+rollback.yml
+  concurrency: rollback-<environment> (cancel-in-progress: false)
+  timeout: 90 min
+      │
+      ├─ Guard: if confirm != 'ROLLBACK', job is skipped entirely
+      ├─ Checkout
+      ├─ Install SF CLI
+      ├─ Download rollback-snapshot-<environment>-<run_id> artifact
+      │    (artifact uploaded by _reusable-validate.yml, retained 30 days)
+      ├─ Authenticate to Salesforce
+      ├─ Guard: if snapshot is empty → ::error:: and exit
+      ├─ sf project deploy start --source-dir rollback-snapshot
+      │    --test-level <test_level input> (env-var safe)
+      └─ Append rollback summary to step summary
+```
+
+> Rollback also requires approval through the target environment gate (e.g., `sfprod` for production rollbacks).
+
+---
+
+### 10. Weekly drift detection (Mondays 06:00 UTC)
+
+**Trigger:** `schedule` cron `0 6 * * 1` OR `workflow_dispatch`
+
+```
+Monday 06:00 UTC (or manual dispatch)
+      │
+      ▼
+drift-detection.yml
+  timeout: 30 min
+  permissions: contents:read, issues:write
+      │
+      ├─ Checkout main
+      ├─ Install SF CLI
+      ├─ Authenticate to Salesforce (sfprod-validation environment)
+      ├─ sf project retrieve start --manifest manifest/package.xml --output-dir drift-check
+      │    (no || true — failures surface and fail the job)
+      ├─ diff -r force-app/main/default drift-check/main/default
+      │    ├─ drift_found=false → [auto-close step]
+      │    └─ drift_found=true  → [open/update issue step]
+      │
+      ├─ [if drift_found=true]
+      │    ├─ Upload drift-report artifact
+      │    └─ Open or append to GitHub issue (label: drift)
+      │         ├─ Existing open drift issue? → add comment with new diff
+      │         └─ No existing issue? → create new issue with label 'drift'
+      │
+      └─ [if drift_found=false]
+           └─ Find open drift issue created by github-actions[bot]
+                ├─ Found? → comment "✅ Drift resolved as of <date>" + close issue
+                └─ Not found? → no-op
+```
+
+---
+
+### 11. Weekly branch cleanup (Sundays 02:00 UTC)
+
+**Trigger:** `schedule` cron `0 2 * * 0` OR `workflow_dispatch` with optional `dry_run` and `days_old`
+
+```
+Sunday 02:00 UTC (or manual dispatch)
+      │
+      ▼
+cleanup-branches.yml
+  timeout: 15 min
+  permissions: contents:write, pull-requests:read
+      │
+      └─ Delete stale and merged branches (github-script)
+           │
+           ├─ DRY_RUN = github.event.inputs.dry_run || 'false'
+           │    ├─ Schedule trigger: dry_run defaults to 'false' → LIVE deletion
+           │    └─ Manual dispatch: dry_run defaults to 'true' → safe preview
+           │
+           ├─ PROTECTED (never deleted): main, master, develop, qa, stage,
+           │    pre-prod-validation, deployments-ledger, release/*, hotfix/*, v*.*.*
+           │    + any branch with GitHub branch protection rules
+           │
+           ├─ For each non-protected branch:
+           │    ├─ Fetch last commit date via GitHub API
+           │    ├─ Check for associated merged/closed PRs
+           │    └─ Delete if: (merged PR OR closed PR OR stale) AND older than DAYS_OLD (default: 60)
+           │
+           └─ Write summary table: deleted / kept / skipped
+```
+
+---
+
+### 12. Manual first-run baseline
+
+**Trigger:** `workflow_dispatch` with `branch` input
+
+```
+Manual: Actions → First-Run Baseline → Run workflow
+  input: branch (name of the branch to baseline)
+      │
+      ▼
+first-run-baseline.yml
+  timeout: 10 min
+  permissions: contents:read
+      │
+      ├─ Checkout the specified branch (branch input via env var — injection-safe)
+      └─ Record baseline to step summary (all lines correctly redirected to $GITHUB_STEP_SUMMARY)
+           ## Baseline established
+           Branch: <branch>
+           Commit: <sha>
+           Subsequent runs use this commit as delta start point.
+```
+
+---
+
+## Workflow reference — every file explained
+
+### Reusable workflows (called by environment workflows, not triggered directly)
+
+| File | Purpose | Called by |
+|---|---|---|
+| `_reusable-validate.yml` | Delta generation, dynamic test selection, rollback snapshot, dry-run validation. Returns `validation_id`, `nothing_to_deploy`. | `sfdev`, `sfqa`, `sfstage`, `sfpreprodvalidation`, `sfprod` |
+| `_reusable-deploy.yml` | Quick-deploy (or full-deploy fallback), pre/post Apex scripts, deployment ledger. | `sfdev`, `sfqa`, `sfstage`, `sfprod` |
+
+### Environment caller workflows (triggered by push/dispatch)
+
+| File | Branch | Test level | Deploys? | Notes |
+|---|---|---|---|---|
+| `sfdev.yml` | `develop` | RunSpecifiedTests | Yes | Dynamic test list |
+| `sfqa.yml` | `qa` | RunLocalTests | Yes | Also receives cherry-picks |
+| `sfstage.yml` | `stage` | RunLocalTests | Yes | |
+| `sfpreprodvalidation.yml` | `pre-prod-validation` | RunAllTestsInOrg | No | Validate-only gate |
+| `sfprod.yml` | `main` | RunAllTestsInOrg | Yes | Manual approval required |
+
+### Utility workflows
+
+| File | Trigger | What it does |
+|---|---|---|
+| `salesforce-pr-review.yml` | PR to `develop`/`qa`/`stage`/`main` | Two-layer review: static rules + Claude AI. Skips Dependabot PRs. `continue-on-error` so review crash never blocks merge. |
+| `cherry-pick-workflow.yml` | PR merged to `develop` (title starts "Cherry") | Cherry-picks to `qa` using `merge_commit_sha`. Handles both regular merge (uses `-m 1`) and squash merge. |
+| `rollback.yml` | Manual dispatch | Restores environment from pre-deploy snapshot artifact. |
+| `drift-detection.yml` | Weekly schedule + manual | Org vs `main` diff. Auto-opens drift issue; auto-closes it when drift resolves. |
+| `cleanup-branches.yml` | Weekly schedule + manual | Deletes merged/stale branches. Schedule runs live; manual dispatch defaults to dry-run. |
+| `first-run-baseline.yml` | Manual dispatch | Creates a successful run record so delta logic has a start commit. |
 
 ---
 
 ## How the AI review agent works
 
-This is the bit you specifically asked about, so here's the full picture.
-
 ### When it runs
 
-On every PR opened or updated against `develop`, `qa`, `stage`, or `main`. It does **not** run on direct pushes — it's a code-review tool, not a deployment guard.
+On every PR opened or updated against `develop`, `qa`, `stage`, or `main`. Skips Dependabot PRs automatically. Does **not** run on direct pushes — it is a code-review tool, not a deployment guard.
 
 ### Two layers, one review
 
-The bot runs two independent layers and merges their findings into a single PR review:
-
 **Layer 1 — Static rules** (`.github/scripts/rules/`)
 
-Deterministic pattern-matching across 30+ rules. Fires regardless of API key. Examples:
+Deterministic pattern-matching, 30+ rules. Fires regardless of API key:
 
-- `SF-APEX-001` — SOQL inside a for/while loop
-- `SF-APEX-002` — DML inside a for/while loop
-- `SF-APEX-004` — silent exception swallowing (catch block that only logs)
-- `SF-APEX-005` — SOQL without `WITH USER_MODE` / `WITH SECURITY_ENFORCED`
-- `SF-APEX-006` — `@AuraEnabled` method without try/catch
-- `SF-TRIG-001` — too much logic in trigger body (use a handler)
-- `SF-TRIG-002` / `003` — SOQL/DML in a trigger body
-- `SF-LWC-001` — hardcoded URL
-- `SF-LWC-002` — imperative Apex with `.then` but no `.catch`
-- `SF-LWC-003` — `document.querySelector` (use template.querySelector)
-- `SF-SEC-001` — `global` access modifier overuse
-- `SF-SEC-002` — class without explicit `with sharing` / `without sharing` / `inherited sharing`
-- `SF-META-001` — API version below team minimum
-- `SF-META-002` — destructive change (file deletion)
+| Rule | What it catches |
+|---|---|
+| SF-APEX-001 | SOQL inside a for/while loop |
+| SF-APEX-002 | DML inside a for/while loop |
+| SF-APEX-004 | Silent exception swallowing (catch that only logs) |
+| SF-APEX-005 | SOQL without `WITH USER_MODE` / `WITH SECURITY_ENFORCED` |
+| SF-APEX-006 | `@AuraEnabled` method without try/catch |
+| SF-TRIG-001 | Too much logic in trigger body |
+| SF-TRIG-002/003 | SOQL/DML in trigger body |
+| SF-LWC-001 | Hardcoded URL |
+| SF-LWC-002 | Imperative Apex `.then` with no `.catch` |
+| SF-LWC-003 | `document.querySelector` (use `template.querySelector`) |
+| SF-SEC-001 | `global` access modifier overuse |
+| SF-SEC-002 | Class without explicit `with sharing` / `without sharing` |
+| SF-META-001 | API version below team minimum |
+| SF-META-002 | Destructive change (file deletion) |
 
 **Layer 2 — Claude Sonnet AI agent** (`.github/scripts/ai-review.js`)
 
-Read-only — explicitly instructed never to write code, only describe issues. Catches things pattern-matching cannot:
+Read-only — never writes code. Catches things pattern-matching cannot:
 
 | Category | What it spots |
 |---|---|
 | CRUD/FLS | `@AuraEnabled` method missing `Schema.sObjectType.X.isCreateable()` checks |
 | Sharing | `without sharing` on a class that exposes user-facing data |
-| Async | `@future` calling another `@future`, Queueable not chained correctly |
-| Trigger ↔ Flow | Record-triggered flow on the same object/event as the trigger |
-| Cross-file impact | Field rename in `Account.object-meta.xml` breaking other Apex that references it |
+| Async | `@future` calling another `@future`; Queueable not chained correctly |
+| Trigger ↔ Flow | Record-triggered flow on same object/event as a trigger |
+| Cross-file impact | Field rename breaking Apex in other files |
 | Method signatures | Public method param change breaking callers elsewhere in the repo |
 | LWC reactivity | Stale state between `@wire` and imperative calls; missing error path |
-| Flow null-safety | Get Records → reference fields without "no records" branch |
+| Flow null-safety | Get Records → field reference without "no records" branch |
 
-The AI layer also receives **context files** automatically. If your PR changes `AccountTrigger.cls`, the agent gets:
-- Other triggers on Account (to spot execution-order conflicts)
-- Flows referencing Account (to spot dual-automation)
-- `Account.object-meta.xml`
+The AI layer also automatically collects **context files** — if your PR changes `AccountTrigger.cls`, the agent also receives other Account triggers, Account flows, and `Account.object-meta.xml`. It reasons over cross-file blast radius, not just the diff.
 
-So it's reasoning over the cross-file blast radius, not just the diff.
-
-### Cost guards (this is the engineering work)
-
-The AI layer is bounded by five guards in `ai-review.js`. In order of impact:
+### Cost guards (in order of impact)
 
 | # | Guard | Effect |
 |---|---|---|
-| 1 | Skip non-logic PRs | XML-only PRs (profiles, translations, layouts) never call the API — $0.00 |
-| 2 | Diff-only for metadata | Non-logic files send the diff only, not full content |
-| 3 | Hard input cap (~12,500 tokens) | Context files are dropped from the tail until the request fits |
-| 4 | Output cap (`max_tokens: 2048`) | Caps the response at ~15 findings |
-| 5 | Context file limit (max 8) | Even with budget, the agent never sees more than 8 related files |
-
-Token usage is logged on every run so you can monitor cost trends.
+| 1 | Skip non-logic PRs | XML-only PRs never call the API — $0.00 |
+| 2 | Diff-only for metadata files | Non-logic files send diff only, not full content |
+| 3 | Hard input cap (~12,500 tokens) | Context files dropped until request fits |
+| 4 | Output cap (`max_tokens: 2048`) | Caps response at ~15 findings |
+| 5 | Context file limit (max 8) | Never sees more than 8 related files regardless of budget |
 
 ### What a finding looks like
 
-The bot posts a single GitHub PR review with inline comments on changed lines. Each finding has:
+The bot posts a single GitHub PR review with inline comments on diff lines:
 
 ```
 🔴 SF-APEX-001 — SOQL query inside a loop. Move the query outside
@@ -339,58 +702,78 @@ the loop and process results in bulk.
 Suggestion: Query before the loop, then iterate over the result set.
 ```
 
-🔴 = high severity, 🟡 = medium, 🔵 = low. **High-severity findings request changes** (the PR cannot be merged until either fixed or dismissed). Medium and low post as comments only.
-
-Findings outside the diff (e.g. impact on a file your PR didn't touch) appear in a summary table in the review body.
+`🔴` high = REQUEST_CHANGES (PR cannot merge until fixed or dismissed).  
+`🟡` medium / `🔵` low = COMMENT only — informational, does not block merge.
 
 ### What it deliberately does NOT do
 
-- Never writes or suggests code (only descriptions)
-- Never requests changes for low/medium findings — only for high
-- Never re-reviews on its own; push a new commit to trigger a new review
-- Never sees secrets, only repo source
+- Never writes or suggests code (descriptions only)
+- Never requests changes for low/medium findings
+- Never re-reviews on its own — push a new commit to trigger a new review
+- Never sees secrets
 
 ---
 
-## Architectural improvements over a baseline pipeline
+## Architectural improvements
 
-These are the architect-level additions over a vanilla `validate → deploy` setup:
+### 1. Concurrency groups on every workflow
 
-### 1. Quick-deploy with validation ID handoff
+Every workflow now declares a `concurrency:` group. If two pushes arrive on the same branch before the first run completes:
 
-The validate job captures the validation deployment ID (valid for 10 days). The deploy job takes that ID and runs `sf project deploy quick`, which **skips re-running Apex tests**. Typical effect:
+- **Deploy and rollback workflows:** `cancel-in-progress: false` — the second run queues, never cancels a deploy mid-flight (which could leave the org in a partial state).
+- **PR review and cherry-pick:** `cancel-in-progress: true` — stale review runs are superseded by the latest push.
 
-- Validate (once): full Apex run, 25–40 minutes
-- Deploy (immediate): quick-deploy, 3–8 minutes
+### 2. Timeout guards on every job
 
-Same correctness, ~70% less wall time on the deploy itself.
+| Job type | Timeout |
+|---|---|
+| Deploy jobs | 90 min |
+| Validate jobs | 60 min |
+| Drift detection | 30 min |
+| Cleanup / cherry-pick / PR review | 15 min |
+| First-run baseline | 10 min |
 
-### 2. Pre-deploy snapshot + rollback workflow
+Prevents hung runners from consuming all available CI minutes.
 
-Before deploying, the validate job retrieves the **current** state of every metadata file in the delta and uploads it as a workflow artifact (`rollback-snapshot-<env>-<run-id>`, retained 30 days).
+### 3. Shell injection hardening
 
-If a deploy goes bad, run the **Rollback Deployment** workflow with the offending run ID. It downloads the snapshot and redeploys it — restoring the exact pre-deployment state.
+All user-controlled or context-controlled values (`github.actor`, `inputs.commit_hash`, `github.ref_name`, `inputs.test_level`, `github.event.pull_request.merge_commit_sha`, etc.) are passed through `env:` blocks and referenced as `$ENV_VAR` in shell — never interpolated directly as `${{ }}` inside `run:` steps. This prevents code injection via crafted branch names, PR titles, or usernames.
 
-> Limitation: NEW components can't be auto-rolled back this way (Salesforce has no rollback for creates). The workflow detects this and tells you.
+### 4. Quick-deploy with validation ID handoff
 
-### 3. Drift detection
+The validate job captures the validation deployment ID (valid 10 days). The deploy job uses `sf project deploy quick --job-id <id>`, skipping the Apex test re-run:
 
-Weekly job that retrieves prod metadata for tracked types and diffs it against `main`. If anything's changed in prod via Setup that didn't come through the pipeline, an issue is auto-opened (or appended to the existing one). Catches the "someone changed it in production directly" class of bugs.
+- Validate (once): full Apex run, 25–40 min
+- Deploy (immediate): quick-deploy, 3–8 min
 
-### 4. Deployment ledger
+Same correctness guarantee, ~70% less wall time on the deploy.
 
-Every deploy writes a JSON record (timestamp, actor, commit, deploy ID, validation ID, outcome) and the workflow auto-commits it to a `deployments-ledger` branch. This is your audit trail. SOC 2 / change advisory board / "who deployed what when" — all answerable in `git log deployments-ledger`.
+### 5. Pre-deploy snapshot + rollback
 
-### 5. Production guardrails
+Before deploying, the validate job retrieves the **current** state of every metadata file in the delta and uploads it as a workflow artifact (`rollback-snapshot-<env>-<run_id>`, retained 30 days). Emergency rollback re-deploys this snapshot. New components cannot be auto-rolled back (the workflow detects this and explains it).
 
-- **`RunAllTestsInOrg` mandatory for prod** (hardcoded in `sfprod.yml`)
-- **Manual approval gate** on the `sfprod` environment via GitHub environment protection
-- **Quick-deploy** kicks in only after that approval is given
-- **Branch protection on `main`** restricts pushes to approvers
+### 6. Drift detection with auto-open and auto-close
 
-### 6. First-run baseline + merge-base fallback
+Weekly job diffs prod metadata against `main`. Auto-opens a GitHub issue if drift is found. If the following week shows no drift, the issue is **automatically closed** with a "drift resolved" comment — no manual housekeeping required.
 
-The standard "what's the previous successful run?" lookup falls back to the merge-base with `develop` if no successful run exists. Means a brand-new branch can run without a manual baseline step — but the baseline workflow is still there for when you want explicit control.
+### 7. Deployment ledger
+
+Every deploy writes a JSON audit record (timestamp, actor, commit SHA, deploy ID, validation ID, test level, outcome) to the `deployments-ledger` git branch. Full audit trail queryable with `git log deployments-ledger`.
+
+### 8. Cherry-pick automation with merge/squash detection
+
+When a PR merged to `develop` has a title starting with "Cherry", its commit is automatically cherry-picked to `qa`, which in turn triggers the QA deploy pipeline. The workflow correctly handles both merge commits (uses `git cherry-pick -m 1`) and squash-merge commits (single-parent, uses direct `git cherry-pick`).
+
+### 9. Production guardrails
+
+- `RunAllTestsInOrg` mandatory for prod (hardcoded in `sfprod.yml`)
+- Manual approval gate on the `sfprod` GitHub environment
+- Quick-deploy runs only after manual approval
+- Branch protection on `main` restricts pushes
+
+### 10. `actions: read` permission on all validate callers
+
+The validate workflow uses the GitHub CLI (`gh run list`) to find the last successful run for delta calculation. This requires `actions: read`. All five caller workflows now declare this permission, ensuring the `gh` command works even in repositories with restricted default token permissions.
 
 ---
 
@@ -398,28 +781,48 @@ The standard "what's the previous successful run?" lookup falls back to the merg
 
 ### "I need to deploy to prod"
 
-1. Open PR from your feature branch → `develop`
-2. Wait for **PR review bot** to comment; address any 🔴 findings
+1. Open PR from feature branch → `develop`
+2. Wait for **PR review bot** to post findings; address any 🔴 issues
 3. Get human approval, merge to `develop` — `sfdev.yml` runs automatically
-4. Open PR `develop` → `qa`, repeat through `stage` and `pre-prod-validation`
-5. Open PR `pre-prod-validation` → `main`
-6. On merge, `sfprod.yml` runs validate; **the deploy job pauses for manual approval**
-7. Approver clicks **Review deployments** → **Approve** in the workflow run
-8. Quick-deploy completes, ledger entry written
+4. Open PR `develop` → `qa`, merge — `sfqa.yml` runs
+5. Open PR `qa` → `stage`, merge — `sfstage.yml` runs
+6. Open PR `stage` → `pre-prod-validation`, merge — `sfpreprodvalidation.yml` validates only
+7. Open PR `pre-prod-validation` → `main`
+8. On merge, `sfprod.yml` runs validate (RunAllTestsInOrg); **deploy pauses for manual approval**
+9. Approver clicks **Review deployments** → **Approve** in the workflow run
+10. Quick-deploy completes; ledger entry written to `deployments-ledger`
+
+### "I need to cherry-pick a hotfix to QA immediately"
+
+1. Create your PR targeting `develop` and give it a title starting with "Cherry" (e.g., `Cherry: Fix null pointer in AccountController`)
+2. Merge the PR
+3. The `cherry-pick-workflow.yml` fires automatically and pushes the commit to `qa`
+4. `sfqa.yml` fires automatically — the fix is deployed to QA without any manual step
 
 ### "Prod broke — get me back"
 
 1. Find the bad workflow run: **Actions** → **SF Prod** → bad run → copy the **Run ID**
 2. **Actions** → **Rollback Deployment** → **Run workflow**
 3. Environment: `sfprod`, Run ID: the one you copied, Confirm: type `ROLLBACK`
-4. Approve the `sfprod` environment gate again
-5. Snapshot redeploys
+4. For speed: set `test_level` to `NoTestRun` (emergency speed); leave as `RunLocalTests` for safety
+5. Approve the `sfprod` environment gate
+6. Snapshot is redeployed; the rollback summary appears in the step summary
 
 ### "Drift was detected"
 
-1. The auto-opened drift issue has the diff
-2. For each item: either reverse-engineer it back into git (and PR through the normal flow) or revert it in the org
-3. Close the issue once the next drift run shows no diff
+1. Check the auto-opened drift issue — it contains the first 200 lines of diff and a link to the full artifact
+2. For each drifted item: either recreate the change in git (PR through the normal flow) or revert it in the org directly
+3. Wait for the next Monday's drift detection run — it will auto-close the issue if no drift remains
+4. Or run the drift detection workflow manually to check immediately
+
+### "I want to preview which branches will be cleaned up"
+
+1. **Actions** → **Cleanup Stale Branches** → **Run workflow**
+2. Set `dry_run` to `true` (the default for manual dispatch)
+3. Review the summary table — it shows every branch that would be deleted and why
+4. To run live: set `dry_run` to `false`
+
+> Note: The scheduled Sunday run (`dry_run=false`) actually deletes branches. Protected branches (main, develop, qa, stage, release/*, hotfix/*, v*.*.*) are never touched.
 
 ### "Rotate JWT keys"
 
@@ -431,7 +834,7 @@ openssl x509 -req -sha256 -days 730 -in server-new.csr -signkey server-new.key -
 
 # In Salesforce: each Connected App → Edit → upload server-new.crt → Save
 # In GitHub: each environment → SF_JWT_KEY → Update with contents of server-new.key
-# Run sfdev.yml manually — if it passes, rotation is complete
+# Verify: run sfdev.yml manually — if it passes, rotation is complete
 ```
 
 ---
@@ -456,26 +859,44 @@ A team doing 50–100 PRs/week is looking at **$5–$15/week** for the AI layer.
 **The PR review workflow doesn't fire**
 - Check the PR base branch — the workflow only triggers on PRs to `develop`, `qa`, `stage`, `main`
 - Check workflow permissions: **Settings** → **Actions** → **General** → **Workflow permissions** = Read and write
+- Dependabot PRs are intentionally skipped — this is expected behavior
 
 **JWT auth fails with `OAUTH_APP_ACCESS_DENIED`**
 - The integration user isn't pre-authorized on the Connected App. Manage → Manage Profiles or Permission Sets.
 
 **JWT auth fails with `JWT validation failed`**
 - The `SF_JWT_KEY` secret is missing the `-----BEGIN PRIVATE KEY-----` / `-----END PRIVATE KEY-----` lines, or has Windows line endings
-- Re-paste the key. On macOS/Linux: `cat server.key | pbcopy` or `xclip -selection clipboard < server.key`
+- Re-paste the key. On macOS/Linux: `cat server.key | pbcopy`
 
 **Quick-deploy fails with "validation ID expired"**
-- Salesforce's 10-day window has passed. Re-run the validate workflow to get a fresh ID, or let the deploy fall back to a full deploy.
+- Salesforce's 10-day window has passed. Re-run the validate workflow to get a fresh ID, or let deploy fall back to full deploy automatically.
 
 **`No prior successful run found`**
 - Run **First-Run Baseline** for that branch, then push again.
 
 **AI layer is silently skipping**
-- Check the workflow log. If it says `ANTHROPIC_API_KEY not set — skipping AI review layer`, the secret isn't configured.
-- If it says `no logic files changed — skipping (cost guard 1)`, that's expected — the PR is XML-only.
+- `ANTHROPIC_API_KEY not set — skipping AI review layer`: the secret isn't configured
+- `no logic files changed — skipping (cost guard 1)`: the PR is XML-only — expected behavior
 
-**`Salesforce PR Review` posts no findings on a PR I expected to fail**
-- Look at the workflow log under "Run review" — confirm static rules ran and how many findings the AI layer returned. Both layers might genuinely have nothing to say.
+**Cherry-pick workflow fails with "Conflict"**
+- The commit being cherry-picked conflicts with changes already on `qa`
+- Resolve: manually cherry-pick locally with conflict resolution, then push to `qa`
+
+**Cherry-pick workflow fails with "merge_commit_sha is empty"**
+- Rare race condition where the PR close event fires before GitHub populates the merge SHA
+- Re-run the workflow manually or re-open and re-close the PR
+
+**Drift detection issues keep re-opening after I close them**
+- The workflow only auto-closes issues it opened itself (author = `github-actions[bot]`) with the exact title `⚠️ Drift detected between Prod org and main`
+- If you closed the issue manually and the drift is still present, the workflow will open a fresh one on the next run
+
+**Scheduled cleanup is deleting branches I want to keep**
+- Add branch name or pattern to the `PROTECTED_BRANCHES` or `PROTECTED_PATTERNS` list in `cleanup-branches.yml`
+- Or add a GitHub branch protection rule — the workflow respects the GitHub API's protection rules
+
+**Rollback says "Snapshot is empty"**
+- The original deployment only created NEW components (no pre-existing metadata to snapshot)
+- Use destructive changes to remove them, or restore manually from a backup
 
 ---
 
@@ -484,18 +905,19 @@ A team doing 50–100 PRs/week is looking at **$5–$15/week** for the AI layer.
 ```
 .github/
 ├── workflows/
-│   ├── _reusable-validate.yml        # shared validate logic
-│   ├── _reusable-deploy.yml          # shared deploy logic with quick-deploy
-│   ├── sfdev.yml                     # develop → SF Dev
-│   ├── sfqa.yml                      # qa → SF QA
-│   ├── sfstage.yml                   # stage → SF Stage
-│   ├── sfprod.yml                    # main → SF Prod (with approval gate)
-│   ├── sfpreprodvalidation.yml       # validation-only on pre-prod
-│   ├── salesforce-pr-review.yml      # PR review bot trigger
-│   ├── rollback.yml                  # manual rollback
-│   ├── drift-detection.yml           # weekly org-vs-main diff
+│   ├── _reusable-validate.yml        # shared validate logic (timeout: 60min, actions:read)
+│   ├── _reusable-deploy.yml          # shared deploy logic + ledger (timeout: 90min)
+│   ├── sfdev.yml                     # develop → SF Dev (concurrency: deploy-sfdev)
+│   ├── sfqa.yml                      # qa → SF QA (concurrency: deploy-sfqa)
+│   ├── sfstage.yml                   # stage → SF Stage (concurrency: deploy-sfstage)
+│   ├── sfprod.yml                    # main → SF Prod, manual approval (concurrency: deploy-sfprod)
+│   ├── sfpreprodvalidation.yml       # pre-prod-validation → validate-only (concurrency: deploy-sfprod-validation)
+│   ├── salesforce-pr-review.yml      # PR review bot (concurrency: pr-review-<PR#>, skip Dependabot)
+│   ├── cherry-pick-workflow.yml      # develop Cherry-prefixed PRs → qa (merge/squash aware)
+│   ├── rollback.yml                  # manual rollback with test_level choice (concurrency: rollback-<env>)
+│   ├── drift-detection.yml           # weekly org-vs-main diff with auto-open + auto-close
 │   ├── first-run-baseline.yml        # one-time baseline per branch
-│   └── cleanup-branches.yml          # weekly stale branch cleanup
+│   └── cleanup-branches.yml          # weekly live deletion + manual dry-run
 ├── actions/
 │   ├── install-sf-cli/               # composite: install @salesforce/cli
 │   ├── install-plugin/               # composite: install an SF plugin
@@ -517,8 +939,13 @@ A team doing 50–100 PRs/week is looking at **$5–$15/week** for the AI layer.
 
 force-app/main/default/               # Salesforce DX project (your code)
 manifest/package.xml                  # used by drift detection
-deployments/                          # ledger entries (auto-committed)
+scripts/
+├── apex/hello.apex                   # sample anonymous Apex (SF: Execute Anonymous Apex)
+├── soql/account.soql                 # sample SOQL query (SELECT Id, Name FROM Account LIMIT 200)
+└── Bash/DeleteBranches.sh            # local branch cleanup utility (cross-platform, protected-branch-safe)
+deployments/                          # ledger entries (auto-committed to deployments-ledger branch)
 sfdx-project.json
+Jenkinsfile                           # stub (pipeline uses GitHub Actions; Jenkinsfile is a legacy placeholder)
 ```
 
 ---

--- a/scripts/Bash/DeleteBranches.sh
+++ b/scripts/Bash/DeleteBranches.sh
@@ -1,22 +1,73 @@
 #!/bin/bash
+set -euo pipefail
 
-# Get the current date in the format YYYY-MM-DD
-current_date=$(date +%Y-%m-%d)
+# Delete local git branches whose last commit is older than 2 months.
+# Protects: current branch, main, master, develop, qa, stage.
+# Safe to run multiple times (already-deleted branches are skipped).
 
-# Calculate the date 2 months ago in the same format
-two_months_ago=$(date -d "$current_date -2 months" +%Y-%m-%d)
+PROTECTED_BRANCHES="main master develop qa stage pre-prod-validation"
+CURRENT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
 
-# Get a list of all local branches
-branches=$(git branch -l)
+# Calculate cutoff date in a cross-platform way (works on macOS/BSD and Linux/GNU)
+if date -v-2m +%Y-%m-%d > /dev/null 2>&1; then
+  # macOS / BSD date
+  TWO_MONTHS_AGO=$(date -v-2m +%Y-%m-%d)
+else
+  # GNU date (Linux)
+  TWO_MONTHS_AGO=$(date -d "2 months ago" +%Y-%m-%d)
+fi
 
-# Iterate over the list of branches
-for branch in $branches; do
-  # Get the date the branch was last modified in the format YYYY-MM-DD
-  last_modified=$(git log -1 --date=short --pretty=format:"%cd" $branch)
+echo "Cutoff date: $TWO_MONTHS_AGO (branches with last commit before this will be deleted)"
+echo ""
 
-  # Compare the date the branch was last modified to the date 2 months ago
-  if [[ $last_modified < $two_months_ago ]]; then
-    # If the branch was last modified before 2 months ago, delete it
-    git branch -d $branch
+DELETED=0
+SKIPPED=0
+
+# Use array-safe branch listing (handles whitespace, strips leading * and spaces)
+while IFS= read -r raw_branch; do
+  branch="${raw_branch#\* }"   # strip current-branch marker
+  branch="${branch#  }"        # strip leading spaces
+  branch="${branch%%[[:space:]]*}" # strip trailing spaces
+
+  [ -z "$branch" ] && continue
+
+  # Skip current branch
+  if [ "$branch" = "$CURRENT_BRANCH" ]; then
+    echo "SKIP $branch (current branch)"
+    SKIPPED=$((SKIPPED + 1))
+    continue
   fi
-done
+
+  # Skip protected branches
+  is_protected=0
+  for protected in $PROTECTED_BRANCHES; do
+    if [ "$branch" = "$protected" ]; then
+      is_protected=1
+      break
+    fi
+  done
+  if [ "$is_protected" -eq 1 ]; then
+    echo "SKIP $branch (protected)"
+    SKIPPED=$((SKIPPED + 1))
+    continue
+  fi
+
+  # Get last commit date for this branch
+  last_modified=$(git log -1 --date=short --pretty=format:"%cd" "$branch" 2>/dev/null || echo "")
+  if [ -z "$last_modified" ]; then
+    echo "SKIP $branch (could not determine last commit date)"
+    SKIPPED=$((SKIPPED + 1))
+    continue
+  fi
+
+  if [[ "$last_modified" < "$TWO_MONTHS_AGO" ]]; then
+    echo "DELETE $branch (last commit: $last_modified)"
+    git branch -d "$branch" || git branch -D "$branch"
+    DELETED=$((DELETED + 1))
+  else
+    echo "KEEP $branch (last commit: $last_modified)"
+  fi
+done < <(git branch --list)
+
+echo ""
+echo "Done. Deleted: $DELETED, Skipped: $SKIPPED"

--- a/scripts/apex/hello.apex
+++ b/scripts/apex/hello.apex
@@ -1,9 +1,9 @@
 // Use .apex files to store anonymous Apex.
 // You can execute anonymous Apex in VS Code by selecting the
 //     apex text and running the command:
-//     SFDX: Execute Anonymous Apex with Currently Selected Text
+//     SF: Execute Anonymous Apex with Currently Selected Text
 // You can also execute the entire file by running the command:
-//     SFDX: Execute Anonymous Apex with Editor Contents
+//     SF: Execute Anonymous Apex with Editor Contents
 
 string tempvar = 'Enter_your_name_here';
 System.debug('Hello World!');

--- a/scripts/soql/account.soql
+++ b/scripts/soql/account.soql
@@ -1,6 +1,6 @@
 // Use .soql files to store SOQL queries.
 // You can execute queries in VS Code by selecting the
 //     query text and running the command:
-//     SFDX: Execute SOQL Query with Currently Selected Text
+//     SF: Execute SOQL Query with Currently Selected Text
 
-SELECT Id, Name FROM Account
+SELECT Id, Name FROM Account LIMIT 200


### PR DESCRIPTION
…, cherry-pick overhaul, README

Fixes open issue #11 (cherry-pick failing on merge commits).

Changes across 17 files:

Security
- Move all github.actor, inputs.*, github.ref_name, github.event.pull_request.* out of run: shell blocks into env: blocks throughout — eliminates shell injection vectors
- rollback: move test_level and summary inputs to env vars
- cherry-pick: guard against empty merge_commit_sha before any git operation

Reliability
- Add concurrency groups to all 13 workflows (cancel-in-progress: false for deploys, true for PR review) — prevents duplicate/parallel deploys to same org
- Add timeout-minutes to every job (90 deploy, 60 validate, 30 drift, 15 utilities, 10 baseline)
- Add actions: read permission to _reusable-validate.yml and all five caller workflows so gh run list works in repos with restricted default token permissions

Bug fixes
- cherry-pick: retarget A/B placeholder branches to develop/qa (real branches); use merge_commit_sha directly; detect merge vs squash via parent count (-m 1 for regular merge, plain cherry-pick for squash); upgrade actions/checkout v3 → v4; fix hardcoded git push origin B
- first-run-baseline: fix step summary bug where only the last echo went to GITHUB_STEP_SUMMARY — now uses block heredoc
- cleanup-branches: fix scheduled run always being dry-run (JS fallback was 'true'); remove unused actions/checkout (github-script never uses local git)
- drift-detection: remove || true from retrieve step so failures surface; add auto-close step when no drift found (only closes bot-opened issues)
- _reusable-validate.yml: remove || true from rollback snapshot retrieve

Improvements
- rollback: add test_level choice input (RunLocalTests/NoTestRun/etc) defaulting to RunLocalTests; add concurrency group
- salesforce-pr-review: add concurrency group, dependabot skip (if: github.actor != 'dependabot[bot]'), continue-on-error: true on review step, timeout
- scripts/Bash/DeleteBranches.sh: cross-platform date (macOS + Linux), set -euo pipefail, while-read loop (fixes * glob expansion bug), protected branch list with summary output
- scripts/apex/hello.apex, scripts/soql/account.soql: SFDX: → SF: in comments; add LIMIT 200 to SOQL query

Docs
- README: full rewrite with workflow trigger map, step-by-step execution order for all 12 workflows, updated architectural improvements section, new runbooks, full troubleshooting