### PR TITLE
fix: cherry-pick concurrency group fallback for push event

### DIFF
--- a/.github/workflows/cherry-pick-workflow.yml
+++ b/.github/workflows/cherry-pick-workflow.yml
@@ -10,7 +10,7 @@ on:
       - develop
 
 concurrency:
-  group: cherry-pick-${{ github.event.pull_request.number }}
+  group: cherry-pick-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
The concurrency group `cherry-pick-${{ github.event.pull_request.number }}` was causing a workflow parse error on every push to develop, because `pull_request.number` is undefined in a push context. This prevented the `pull_request: closed` trigger from ever firing correctly.

Fix: add `|| github.run_id` fallback so the expression always evaluates to a non-empty string regardless of event type.