### PR TITLE
chore: sync qa baseline before cherry-pick (add getRecentAccountCount prerequisite)

### DIFF
--- a/force-app/main/default/classes/AccountController.cls
+++ b/force-app/main/default/classes/AccountController.cls
@@ -19,4 +19,16 @@ public with sharing class AccountController {
             LIMIT 200
         ];
     }
+
+    @AuraEnabled(cacheable=true)
+    public static Integer getRecentAccountCount(Integer days) {
+        Integer windowDays = (days == null || days <= 0) ? 30 : days;
+        DateTime cutoff = DateTime.now().addDays(-windowDays);
+        return [
+            SELECT COUNT()
+            FROM Account
+            WHERE CreatedDate >= :cutoff
+            WITH USER_MODE
+        ];
+    }
 }


### PR DESCRIPTION
The cherry-pick of PR #21 into qa failed with a conflict because qa was missing the getRecentAccountCount method that was added earlier on develop. This PR brings qa up to the correct baseline so future cherry-picks apply cleanly.